### PR TITLE
NPCBots: Fix build

### DIFF
--- a/src/AutoBalance.cpp
+++ b/src/AutoBalance.cpp
@@ -5159,7 +5159,7 @@ public:
         {
             LOG_DEBUG("module.AutoBalance", "AutoBalance:: {}", SPACER);
 
-            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::Creature_SelectLevel: Creature {} ({}) | Entry ID: ({}) | Spawn ID: ({})",
+            LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnCreatureSelectLevel: Creature {} ({}) | Entry ID: ({}) | Spawn ID: ({})",
                         creature->GetName(),
                         creature->GetLevel(),
                         creature->GetEntry(),
@@ -5168,7 +5168,7 @@ public:
 
             if (creatureABInfo->isBrandNew)
             {
-                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::Creature_SelectLevel: Creature {} ({}) | is no longer brand new.",
+                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnCreatureSelectLevel: Creature {} ({}) | is no longer brand new.",
                             creature->GetName(),
                             creature->GetLevel()
                 );
@@ -5187,7 +5187,7 @@ public:
 
             if (creature->GetLevel() != creatureABInfo->selectedLevel && isCreatureRelevant(creature))
             {
-                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::Creature_SelectLevel: Creature {} ({}) | is set to level ({}).",
+                LOG_DEBUG("module.AutoBalance", "AutoBalance_AllCreatureScript::OnCreatureSelectLevel: Creature {} ({}) | is set to level ({}).",
                             creature->GetName(),
                             creature->GetLevel(),
                             creatureABInfo->selectedLevel
@@ -5197,7 +5197,7 @@ public:
         }
         else
         {
-            LOG_ERROR("module.AutoBalance", "AutoBalance_AllCreatureScript::Creature_SelectLevel: Creature {} ({}) | is new to the instance but wasn't flagged as brand new. Please open an issue.",
+            LOG_ERROR("module.AutoBalance", "AutoBalance_AllCreatureScript::OnCreatureSelectLevel: Creature {} ({}) | is new to the instance but wasn't flagged as brand new. Please open an issue.",
                         creature->GetName(),
                         creature->GetLevel()
             );
@@ -6320,16 +6320,16 @@ public:
         Powers pType = creature->getPowerType();
 
         creature->SetArmor(newFinalArmor);
-        creature->SetModifierValue(UNIT_MOD_ARMOR, BASE_VALUE, (float)newFinalArmor);
+        creature->SetStatFlatModifier(UNIT_MOD_ARMOR, BASE_VALUE, (float)newFinalArmor);
         creature->SetCreateHealth(newFinalHealth);
         creature->SetMaxHealth(newFinalHealth);
         creature->ResetPlayerDamageReq();
         creature->SetCreateMana(newFinalMana);
         creature->SetMaxPower(Powers::POWER_MANA, newFinalMana);
-        creature->SetModifierValue(UNIT_MOD_ENERGY, BASE_VALUE, (float)100.0f);
-        creature->SetModifierValue(UNIT_MOD_RAGE, BASE_VALUE, (float)100.0f);
-        creature->SetModifierValue(UNIT_MOD_HEALTH, BASE_VALUE, (float)newFinalHealth);
-        creature->SetModifierValue(UNIT_MOD_MANA, BASE_VALUE, (float)newFinalMana);
+        creature->SetStatFlatModifier(UNIT_MOD_ENERGY, BASE_VALUE, (float)100.0f);
+        creature->SetStatFlatModifier(UNIT_MOD_RAGE, BASE_VALUE, (float)100.0f);
+        creature->SetStatFlatModifier(UNIT_MOD_HEALTH, BASE_VALUE, (float)newFinalHealth);
+        creature->SetStatFlatModifier(UNIT_MOD_MANA, BASE_VALUE, (float)newFinalMana);
         creatureABInfo->ScaledHealthMultiplier = scaledHealthMultiplier;
         creatureABInfo->ScaledManaMultiplier = scaledManaMultiplier;
         creatureABInfo->ScaledArmorMultiplier = scaledArmorMultiplier;


### PR DESCRIPTION
## Changes Proposed:
- SetModifierValue -> SetStatFlatModifier

- Log_Debug rename for consistency
Creature_SelectLevel -> OnCreatureSelectLevel

## Issues Addressed:
- Build Failing

## SOURCE:
- Creature.cpp https://github.com/trickerer/AzerothCore-wotlk-with-NPCBots/commit/b369714e0a67417f0e794193ff126c2b8a745884#diff-2222cde2ff898034f0ce38bba2d5755cbdeef050c328b2d56599bc6d6664afc1

## Tests Performed:
- No build error
- No server crash
- Logged with player account level 24


## How to Test the Changes:

1. Check Branch
2. Build server
3. Start server and log in game
4. Hire bot and add to party
5. Went to ragefire level 24 with bot, creature scaled
